### PR TITLE
[LIBSEARCH-768] Accessibility Issue - Multiple Form Labels with Permalink in MGet It views. 

### DIFF
--- a/app/views/umlaut/_footer.html.erb
+++ b/app/views/umlaut/_footer.html.erb
@@ -17,8 +17,16 @@
     </p>
 
     <div class="permalink-container permalink-footer">
-      <label for="permalink">Permalink:</label>
-      <input class="permalink" id="permalink" type="text" readonly value="<%= render_umlaut_permalink_url %>" />
+      <label for="permalink-footer">Permalink<span class="hidden"> (Footer)</span>:</label>
+      <input
+        class="permalink"
+        name="permalink-footer"
+        id="permalink-footer"
+        type="text"
+        readonly
+        value="<%= render_umlaut_permalink_url %>"
+        autocomplete="off"
+      />
     </div>
   </div>
 </footer>

--- a/app/views/umlaut/_footer.html.erb
+++ b/app/views/umlaut/_footer.html.erb
@@ -17,7 +17,7 @@
     </p>
 
     <div class="permalink-container permalink-footer">
-      <label for="permalink-footer">Permalink<span class="hidden"> (Footer)</span>:</label>
+      <label for="permalink-footer"><span class="hidden">Footer </span>Permalink:</label>
       <input
         class="permalink"
         name="permalink-footer"

--- a/app/views/umlaut/_header.html.erb
+++ b/app/views/umlaut/_header.html.erb
@@ -17,7 +17,7 @@
     </a>
 
     <div class="permalink-container permalink-header">
-      <label for="permalink-header">Permalink<span class="hidden"> (Header)</span>:</label>
+      <label for="permalink-header"><span class="hidden">Header </span>Permalink:</label>
       <input
         class="permalink"
         name="permalink-header"

--- a/app/views/umlaut/_header.html.erb
+++ b/app/views/umlaut/_header.html.erb
@@ -17,8 +17,16 @@
     </a>
 
     <div class="permalink-container permalink-header">
-      <label for="permalink">Permalink:</label>
-      <input class="permalink" id="permalink" type="text" readonly value="<%= render_umlaut_permalink_url %>" />
+      <label for="permalink-header">Permalink<span class="hidden"> (Header)</span>:</label>
+      <input
+        class="permalink"
+        name="permalink-header"
+        id="permalink-header"
+        type="text"
+        readonly
+        value="<%= render_umlaut_permalink_url %>"
+        autocomplete="off"
+      />
     </div>
 
     <div class="clearfix"></div>


### PR DESCRIPTION
# Overview

The `id` used on each Permalink `input` were not unique, and needed to be changed.

## `autocomplete`
Autocomplete was also added on each input, as it is recommended for accessibility. Since each `input` it set to `readonly`, I set the `autocomplete` attribute to `off`.

## Testing
- Make sure the PR is consistent in these browsers:
  - [x] Chrome
  - [x] Firefox
  - [x] Safari
  - [ ] Edge
- Run accessibility tests:
  - [x] WAVE
  - [x] ARC Toolkit
  - [x] axe DevTools