### PR TITLE
[LIBSEARCH-842] Add Google Tag Manager Tracking Code to MGet It

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,12 +1,39 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <!-- Google Tag Manager -->
+  <script>
+    (function (w, d, s, l, i) {
+      w[l] = w[l] || [];
+      w[l].push({
+        'gtm.start': new Date().getTime(),
+        event: 'gtm.js',
+      });
+      var f = d.getElementsByTagName(s)[0],
+        j = d.createElement(s),
+        dl = l != 'dataLayer' ? '&l=' + l : '';
+      j.async = true;
+      j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+      f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', 'dataLayer', 'GTM-5KZ8T2S');
+  </script>
+  <!-- End Google Tag Manager -->
   <title>Mgetit</title>
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
 </head>
 <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript>
+    <iframe
+      src="https://www.googletagmanager.com/ns.html?id=GTM-5KZ8T2S"
+      height="0"
+      width="0"
+      style="display: none; visibility: hidden;"
+    ></iframe>
+  </noscript>
+  <!-- End Google Tag Manager (noscript) -->
 
 <%= yield %>
 

--- a/app/views/layouts/umlaut.html.erb
+++ b/app/views/layouts/umlaut.html.erb
@@ -1,6 +1,23 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Google Tag Manager -->
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({
+          'gtm.start': new Date().getTime(),
+          event: 'gtm.js',
+        });
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != 'dataLayer' ? '&l=' + l : '';
+        j.async = true;
+        j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+        f.parentNode.insertBefore(j, f);
+      })(window, document, 'script', 'dataLayer', 'GTM-5KZ8T2S');
+    </script>
+    <!-- End Google Tag Manager -->
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <%= csrf_meta_tags %>
@@ -11,6 +28,16 @@
     <%= render_umlaut_head_content %>
   </head>
   <body class="no-js">
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe
+        src="https://www.googletagmanager.com/ns.html?id=GTM-5KZ8T2S"
+        height="0"
+        width="0"
+        style="display: none; visibility: hidden;"
+      ></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <%= render :partial => "umlaut/header" %>
 
     <div class="heading-container">


### PR DESCRIPTION
# Overview

[LIBSEARCH-842](https://mlit.atlassian.net/browse/LIBSEARCH-842)
 
> As part of the Google Analytics 4 Migration and Library Search Web Analytics work we want to collocate and align analytics in the GA4 property for Library Search by adding the Google Tag Manager code snippet to MGet It views, Askwith Media Booking view, and Library Account views. This will allow us to manage and track interactions between U-M Library Search, Library Account, MGet It, and Askwith Media Booking view to better understand  user journeys involving finding, requesting and accessing physical and electronic materials at the Library.