### PR TITLE
Remove pages when it's a hyphen.

### DIFF
--- a/lib/link_resolver/request.rb
+++ b/lib/link_resolver/request.rb
@@ -5,6 +5,12 @@ module LinkResolver
 
     def self.for_raw_request(raw_request)
       context_object = OpenURL::ContextObject.new_from_kev(raw_request.query_string)
+
+      pages = context_object.referent&.get_metadata('pages')
+      if pages && pages == '-'
+        context_object.referent.set_metadata('pages', '')
+      end
+
       context_object.serviceType.clear
 
       new(raw_request, context_object)


### PR DESCRIPTION
When our links get passed on to Gale, and they contain `pages=-` Gale's resolver throws an error message.  Since it provides no data, removing it here is fine.