### PR TITLE
Try it without an isbn, too.

### DIFF
--- a/lib/link_resolver/alma/client.rb
+++ b/lib/link_resolver/alma/client.rb
@@ -30,7 +30,7 @@ module LinkResolver
         return option_list unless request.referent&.format == 'book'
         new_query_string = request.raw_request.query_string
 
-        while option_list.empty? && new_query_string.scan('isbn=').length > 1
+        while option_list.empty? && new_query_string.scan('isbn=').length > 0
           found = false
           new_query_string = new_query_string.split('&').reject do |kev|
             !found && kev.include?('isbn=') && found = true


### PR DESCRIPTION
When the openurl only has a one isbn and it's for a physical edition, the lookup fails in Alma, even if other metadata could otherwise be resolved.

So continue this loop until there are no isbns in the openurl, and that will fix those situations.