### PR TITLE
Process all OpenURL hash keys as lower case

### DIFF
--- a/gems/openurl/lib/openurl/context_object.rb
+++ b/gems/openurl/lib/openurl/context_object.rb
@@ -172,6 +172,12 @@ module OpenURL
 
     def import_kev(kev)
       co = CGI.parse(kev)
+      co.keys.each do |key|
+        lc = key.downcase
+        next if lc == key
+        co[lc] = (co[lc] || []) + co[key]
+        co.delete(key)
+      end
       co2 = {}
       co.each do |key, val|
         if val.is_a?(Array)

--- a/gems/openurl/test/context_object_test.rb
+++ b/gems/openurl/test/context_object_test.rb
@@ -34,6 +34,8 @@ class ContextObjectTest < Test::Unit::TestCase
     test_kev_01_values(ctx)
     ctx = OpenURL::ContextObject.new_from_kev(data["context_objects"]["kev_0_1_nonstandard"])
     test_kev_01_nonstandard_values(ctx)
+    ctx = OpenURL::ContextObject.new_from_kev(data["context_objects"]["kev_case_insensitive"])
+    self.test_kev_case_insensitive(ctx)
   end
 
   def test_old_sid_translation
@@ -472,6 +474,27 @@ class ContextObjectTest < Test::Unit::TestCase
   def test_kev_01_nonstandard_values(ctx)
     assert(ctx.referent.identifiers.index("info:doi/10.1126/science.275.5304.1320").is_a?(Integer))
     assert(ctx.referent.identifiers.index("info:pmid/12345").is_a?(Integer))
+  end
+
+  def test_kev_case_insensitive(ctx)
+    assert(ctx.referrer.identifiers.index('info:sid/myid:mydb').is_a?(Fixnum))
+    assert(ctx.referent.identifiers.index('info:doi/10.1126/science.275.5304.1320').is_a?(Fixnum))
+    assert(ctx.referent.identifiers.index('info:pmid/9036860').is_a?(Fixnum))
+    assert_match(/info:doi\/10\.1126\/science\.275\.5304\.1320|info:pmid\/9036860/, ctx.referent.identifier)
+    assert_equal(ctx.referent.format, 'journal')
+    assert_equal(ctx.referent.metadata['atitle'], "Isolation of a common receptor for coxsackie B")
+    assert_equal(ctx.referent.metadata['title'], "Science")
+    assert_equal(ctx.referent.metadata['genre'], 'article')
+    assert_equal(ctx.referent.metadata['aulast'], 'Bergelson')
+    assert_equal(ctx.referent.metadata['auinit'], 'J')
+    assert_equal(ctx.referent.metadata['date'], '1997')
+    assert_equal(ctx.referent.metadata['volume'], '275')
+    assert_equal(ctx.referent.metadata['spage'], '1320')
+    assert_equal(ctx.referent.metadata['epage'], '1323')
+
+    # Check administrative values
+    assert_equal(ctx.admin["ctx_enc"]["value"], "info:ofi/enc:UTF-8")
+    assert_equal(ctx.admin["ctx_ver"]["value"], "Z39.88-2004")
   end
 
   def test_xml_values(ctx)

--- a/gems/openurl/test/test.yml
+++ b/gems/openurl/test/test.yml
@@ -4,6 +4,7 @@ context_objects:
     kev_hybrid: url_ver=Z39.88-2004&url_ctx_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Actx&rfr_id=info%3Asid%2Fmyid.com%3Amydb&sid=myid%3Amydb&rft_id=info%3Adoi%2F10.1126%2Fscience.275.5304.1320&rft_id=info%3Apmid%2F9036860&id=doi%3A10.1126%2Fscience.275.5304.1320&id=pmid%3A9036860&rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&rft.genre=article&rft.atitle=Isolation+of+a+common+receptor+for+coxsackie+B&rft.jtitle=Science&rft.aulast=Bergelson&rft.auinit=J&rft.date=1997&rft.volume=275&rft.spage=1320&rft.epage=1323&genre=article&atitle=Isolation+of+a+common+receptor+for+coxsackie+B&title=Science&aulast=Bergelson&auinit=J&date=1997&volume=275&spage=1320&epage=1323
     kev_0_1: sid=myid%3Amydb&id=doi%3A10.1126%2Fscience.275.5304.1320&id=pmid%3A9036860&genre=article&atitle=Isolation+of+a+common+receptor+for+coxsackie+B&title=Science&aulast=Bergelson&auinit=J&date=1997&volume=275&spage=1320&epage=1323
     kev_0_1_nonstandard: doi=10.1126/science.275.5304.1320&id=1&pmid=12345
+    kev_case_insensitive: SID=myid%3Amydb&id=doi%3A10.1126%2Fscience.275.5304.1320&ID=pmid%3A9036860&genre=article&atitle=Isolation+of+a+common+receptor+for+coxsackie+B&title=Science&aulast=Bergelson&auinit=J&date=1997&VOLume=275&SpAgE=1320&EpAgE=1323
     xml_doc: test/data/yu.xml
     oai_dc_ctx: test/data/dc_ctx.xml
     marc_21_ctx: test/data/marc_ctx.xml


### PR DESCRIPTION
OpenURL::ContextObject#import_kev is currently case sensitive.

Some vendors produce openurls with mixed case, so this is a problem for us.