### PR TITLE
Work with Case Insensitive URI Schemas

### DIFF
--- a/gems/openurl/lib/openurl/context_object_entity.rb
+++ b/gems/openurl/lib/openurl/context_object_entity.rb
@@ -240,7 +240,7 @@ module OpenURL
     # into info URIs.
     def self.normalize_id(value)
       value =~ /^(\w+)(:|\/)(.*)/
-      prefix = $1
+      prefix = $1.downcase
       remainder = $3
       # info ones
       if ["doi", "pmid", "oclcnum", "sici", "lccn", "sid"].include?(prefix)

--- a/gems/openurl/test/context_object_entity_test.rb
+++ b/gems/openurl/test/context_object_entity_test.rb
@@ -12,6 +12,7 @@ class ContextObjectEntityTest < Test::Unit::TestCase
     # some info ones
 
     assert_equal "info:doi/10.1126/science.275.5304.1320", init_and_return_id("doi:10.1126/science.275.5304.1320")
+    assert_equal "info:doi/10.1126/science.275.5304.1320", init_and_return_id("DOI:10.1126/science.275.5304.1320")
 
     assert_equal "info:pmid/9036860", init_and_return_id("pmid:9036860")
 


### PR DESCRIPTION
Some vendors produce URI schemas for identifiers like DOI's in all-caps. This change allows us to parse those.