### PR TITLE
Adding Design System components.

### DIFF
--- a/lib/views/application.erb
+++ b/lib/views/application.erb
@@ -36,9 +36,11 @@
   </script>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@umich-lib/web@latest/umich-lib.css"/>
     <link href="/assets/stylesheets/mgetit.css" media="screen" rel="stylesheet" type='text/css' />
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,600italic,700,700italic,800,800italic' rel='stylesheet' type='text/css' />
     <script src="/assets/javascripts/mgetit.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@umich-lib/web@latest/dist/umich-lib/umich-lib.esm.js"></script>
     <title>MGet It</title>
   </head>
   <body class="no-js">
@@ -52,6 +54,7 @@
       ></iframe>
     </noscript>
     <!-- End Google Tag Manager (noscript) -->
+    <m-universal-header></m-universal-header>
     <%= erb :header, locals: {request: request} %>
 
     <div class="heading-container">
@@ -68,5 +71,6 @@
     </div>
 
     <%= erb :footer, locals: {request: request} %>
+    <m-chat></m-chat>
   </body>
 </html>

--- a/lib/views/header.erb
+++ b/lib/views/header.erb
@@ -1,28 +1,16 @@
 <%# local implementers may over-ride this partial for custom local header.
     This partial is called by default umlaut layout.  %>
-<header class="site-header">
-  <div class="container-fluid">
-
-    <a href="http://umich.edu" class="site-brand-umich-block-m-logo">
-      <img src="<%= asset_path('umich_block_m.png') %>" alt="University of Michigan"/>
-    </a>
-    <a href="/" class="site-brand-mlibrary-logo">
-      <img src="<%= asset_path('mlibrary_logo.png') %>" alt="Library"/>
-    </a>
-
-    <div class="permalink-container permalink-header">
-      <label for="permalink-header"><span class="hidden">Header </span>Permalink:</label>
-      <input
-        class="permalink"
-        name="permalink-header"
-        id="permalink-header"
-        type="text"
-        readonly
-        value="<%= request.permalink_url %>"
-        autocomplete="off"
-      />
-    </div>
-
-    <div class="clearfix"></div>
+<m-website-header variant='dark'>
+  <div class="permalink-container permalink-header">
+    <label for="permalink-header"><span class="hidden">Header </span>Permalink:</label>
+    <input
+      class="permalink"
+      name="permalink-header"
+      id="permalink-header"
+      type="text"
+      readonly
+      value="<%= request.permalink_url %>"
+      autocomplete="off"
+    />
   </div>
-</header>
+</m-website-header>

--- a/public/citation-linker/assets/stylesheets/main.css
+++ b/public/citation-linker/assets/stylesheets/main.css
@@ -382,6 +382,8 @@ textarea {
   display: none; }
 
 .footer {
+  background: #00274C;
+  padding: 1rem 0;
   margin-top: 2rem; }
 
 .container-fluid,

--- a/public/citation-linker/index.html
+++ b/public/citation-linker/index.html
@@ -38,11 +38,11 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@umich-lib/web@latest/umich-lib.css"/>
     <link rel="stylesheet" href="assets/stylesheets/main.css" />
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,300italic,400italic,600,600italic,700,700italic,800,800italic' rel='stylesheet' type='text/css' />
     <link href='https://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700,700italic' rel='stylesheet' type='text/css'>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@umich-lib/css@latest/dist/umich-lib.css"/>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@umich-lib/components@latest/dist/umich-lib/umich-lib.esm.js"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@umich-lib/web@latest/dist/umich-lib/umich-lib.esm.js"></script>
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->
@@ -56,18 +56,7 @@
     </noscript>
     <!-- End Google Tag Manager (noscript) -->
     <m-universal-header></m-universal-header>
-    <header>
-      <div class="site-header">
-        <div class="container-fluid">
-          <a href="http://umich.edu" class="site-brand-umich-block-m-logo">
-            <img src="assets/images/umich_block_m.png" alt="Go to the University of Michigan homepage">
-          </a>
-          <a href="http://lib.umich.edu" class="site-brand-mlibrary-logo">
-            <img src="assets/images/mlibrary_logo.png" alt="Go to the University of Michigan Library homepage">
-          </a>
-        </div>
-      </div>
-    </header>
+    <m-website-header variant="dark"></m-website-header>
 
     <div class="callout spacing-top-bottom-2">
       <div class="page-container">
@@ -279,8 +268,21 @@
 
     </div>
 
-    <footer class="footer">
-
+    <footer id="footer" class="footer">
+      <div class="container">
+        <div class="permalink-container permalink-footer">
+          <!-- <label for="permalink-footer"><span class="hidden">Footer </span>Permalink:</label>
+          <input
+            class="permalink"
+            name="permalink-footer"
+            id="permalink-footer"
+            type="text"
+            readonly
+            value="<%= request.permalink_url %>"
+            autocomplete="off"
+          /> -->
+        </div>
+      </div>
     </footer>
 
     <m-chat></m-chat>

--- a/public/citation-linker/index.html
+++ b/public/citation-linker/index.html
@@ -268,22 +268,7 @@
 
     </div>
 
-    <footer id="footer" class="footer">
-      <div class="container">
-        <div class="permalink-container permalink-footer">
-          <!-- <label for="permalink-footer"><span class="hidden">Footer </span>Permalink:</label>
-          <input
-            class="permalink"
-            name="permalink-footer"
-            id="permalink-footer"
-            type="text"
-            readonly
-            value="<%= request.permalink_url %>"
-            autocomplete="off"
-          /> -->
-        </div>
-      </div>
-    </footer>
+    <footer id="footer" class="footer"></footer>
 
     <m-chat></m-chat>
 


### PR DESCRIPTION
The necessary CDNs to run the latest version of the Design System has been added, along with these three components:
* `m-universal-header`
* `m-chat`
* `m-website-header` (replacing `<header>`)