### PR TITLE
[LIBSEARCH-1084] Change references to 7FAST to "Document Delivery" in MGet It

### DIFF
--- a/lib/views/not_available_online.erb
+++ b/lib/views/not_available_online.erb
@@ -11,7 +11,7 @@
 
   <% if not_available_online[1].url %>
     <%= link_to('Request to have a copy delivered', "/link_router/index/#{not_available_online[1].id}") %>
-    <span class="small-help-text">(Interlibrary Loan, 7Fast)</span>
+    <span class="small-help-text">(Interlibrary Loan, Document Delivery)</span>
   <% end %>
 </div>
 <% end %>

--- a/lib/views/not_available_online_2.erb
+++ b/lib/views/not_available_online_2.erb
@@ -9,7 +9,7 @@
       <%= link_to('searching the library catalog', "/link_router/index/#{not_available_online_2[0].id}") %>
       or
       <%= link_to('request to have a copy delivered', "/link_router/index/#{not_available_online_2[1].id}") %>
-      (Interlibrary Loan, 7Fast).
+      (Interlibrary Loan, Document Delivery).
     </p>
   </div>
 <% end %>


### PR DESCRIPTION
From [LIBSEARCH-1084](https://mlit.atlassian.net/browse/LIBSEARCH-1084):
> In (at least) two places on MGet It screens, there’s a reference to the retired “7FAST” service. That’s been replaced with “Document Delivery”.
> 
> In the right sidebar, under the “Not available online?” heading, there’s explanatory text “InterLibrary Loan, 7FAST”).
> 
> * Change 7FAST to “Document Delivery”
> * Remove internal capital L from “InterLibrary” so it reads “Interlibrary”
> 
> When there are no options for delivery, in the main part of the page, there’s explanatory text “Interlibrary Loan, 7FAST”)
> 
> * Change 7FAST to “Document Delivery”

I could not find an instance of `InterLibrary`.