### PR TITLE
Ignore local .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 *.swp
 /coverage
 /.sass-cache
+
+# Make sure we don't add/commit local environment defintions
+/.env


### PR DESCRIPTION
May be good to ignore local .env files, so they don't get committed accidentally.