### PR TITLE
`docker-compose` is deprecated, should now be `docker compose`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ Getting started for the first time. Or without a populated database schema.
 Because ActiveRecord expects the database schema to be present on startup, you'll need to bring up the database and populate it before bringing up the webserver.
 
 ```bash
-docker-compose up --build --no-start
-docker-compose start mysql-web
-docker-compose run --rm web bundle install
-docker-compose run --rm web bundle exec rake db:migrate
-docker-compose run --rm web bundle exec rake assets:precompile
-docker-compose up
+docker compose up --build --no-start
+docker compose start mysql-web
+docker compose run --rm web bundle install
+docker compose run --rm web bundle exec rake db:migrate
+docker compose run --rm web bundle exec rake assets:precompile
+docker compose up
 ```
 
 Getting started with a populated database schema
 
-`docker-compose up` or `docker-compose start`
+`docker compose up` or `docker compose start`
 
 
 


### PR DESCRIPTION
Just updating the instructions in the ReadMe to use `docker compose`, since `docker-compose` (with the hyphen) is deprecated.