### PR TITLE
Adding Dependabot multi-ecosystem

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @bertrama

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+
+multi-ecosystem-groups:
+  app-dependencies:
+    schedule:
+      interval: "monthly"
+      time: "06:00"
+      day: "monday"
+      timezone: "America/Detroit"
+    commit-message:
+      prefix: "Monthly dependency updates: "
+
+updates:
+  # For GitHub Actions updates
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    multi-ecosystem-group: "app-dependencies"
+    patterns: ["*"]
+
+  # For Bundler/Ruby
+  - package-ecosystem: "bundler"
+    directory: "/"
+    multi-ecosystem-group: "app-dependencies"
+    patterns: ["*"]
+
+  # For Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    multi-ecosystem-group: "app-dependencies"
+    patterns: ["*"]
+
+  # For Docker Compose
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    multi-ecosystem-group: "app-dependencies"
+    patterns: ["*"]


### PR DESCRIPTION
# Overview
In an effort to provide monthly updates, this pull request sets up Dependabot to run every first Monday of the month at 6:00am. If there are available updates, it will create a pull request and assign the users listed in the `CODEOWNERS` file as the reviewers.

Dependabot will run updates these package managers:
- GitHub Actions
- Bundler
- Docker
- Docker Compose

When the updates and merging do not consistently produce problems, a workflow can be added for automatic merging.